### PR TITLE
Error handler middleware

### DIFF
--- a/backend/middleware/error.middleware.js
+++ b/backend/middleware/error.middleware.js
@@ -1,0 +1,17 @@
+const ErrorHandler = (error , request , response , next ) => {
+    Error  = { ...error}
+    Error.message = error.message
+
+    // Mongoose bad object id
+    if (Error.name == 'CastError') {
+            Error.message = "Invalid Resource ID!!"
+            Error.statusCode = 400
+    }
+    
+    response.status(Error.statusCode || 500).json({
+        success: false,
+        message: Error.message || "Internal Server Error😔"
+    });
+}
+
+export default ErrorHandler

--- a/backend/middleware/error.middleware.js
+++ b/backend/middleware/error.middleware.js
@@ -7,7 +7,10 @@ const ErrorHandler = (error , request , response , next ) => {
             Error.message = "Invalid Resource ID!!"
             Error.statusCode = 400
     }
-    
+    if (Error.code == 11000) {
+        Error.statusCode = 409
+        Error.message =  "Duplicate field value entered"
+    }
     response.status(Error.statusCode || 500).json({
         success: false,
         message: Error.message || "Internal Server Error😔"


### PR DESCRIPTION
## Summary
- Added a global error-handling middleware
- Centralizes API error responses

## Behavior
- `400` for invalid MongoDB ObjectId
- `409` for duplicate key conflicts
- `500` for unhandled server errors

## Impact
- No breaking API changes
- More consistent and predictable error responses
